### PR TITLE
Reintroduced comment stubs to generators, and added very basic unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/
 obj/
 bin/
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.vscode/
 obj/
 bin/
 *.swp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Testing"]
+	path = Testing
+	url = https://github.com/Entomy/Testing

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Testing"]
 	path = Testing
 	url = https://github.com/Entomy/Testing
+[submodule "Generics"]
+	path = Generics
+	url = https://github.com/Entomy/Generics

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,7 +10,8 @@
 			"args": [
 				"-P",
 				"agen",
-				"-p"
+				"-p",
+				"-Xmode=debug"
 			],
 			"group": {
 				"kind": "build",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,11 +7,27 @@
 			"label": "build",
 			"type": "shell",
 			"command": "gnatmake",
-			"args": ["-P", "gnatgen", "-p"],
+			"args": [
+				"-P",
+				"agen",
+				"-p"
+			],
 			"group": {
 				"kind": "build",
 				"isDefault": true
 			}
+		},
+		{
+			"label": "build tests",
+			"type": "shell",
+			"command": "gnatmake",
+			"args": [
+				"-P",
+				"tests",
+				"-p"
+			],
+			"group": "build",
+			"problemMatcher": []
 		}
 	]
 }

--- a/src/actions-comment.adb
+++ b/src/actions-comment.adb
@@ -1,3 +1,17 @@
+-- Copyright 2014-2019 Simon Symeonidis (psyomn)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 with Ada.Text_IO; use Ada.Text_IO;
 with Ada.Characters.Handling; use Ada.Characters.Handling;
 with Agen; use Agen;
@@ -5,97 +19,98 @@ with Argument_Stack;
 
 package body Actions.Comment is
 
-  procedure Help is
-  begin
-    Put_Line("  (cmm|comment)");
-    Put_Line("    (desc|description) <message> - Print a description doc comment");
-    Put_Line("    (ex|exception) <name> <mesage> - Print an exception doc comment");
-    Put_Line("    field <name> <message> - Print a field doc comment");
-    Put_Line("    param <name> <message> - Print a param doc comment");
-    Put_Line("    (ret|return) <message> - Prints a return doc comment");
-    Put_Line("    (summ|summary) <message> - Print a summary doc comment");
-    Put_Line("    value <name> <message> - Print a value doc comment");
-  end Help;
+   procedure Help is
+   begin
+      Put_Line("  (cmm|comment)");
+      Put_Line("    (desc|description) <message> - Print a description doc comment");
+      Put_Line("    (ex|exception) <name> <mesage> - Print an exception doc comment");
+      Put_Line("    field <name> <message> - Print a field doc comment");
+      Put_Line("    param <name> <message> - Print a param doc comment");
+      Put_Line("    (ret|return) <message> - Prints a return doc comment");
+      Put_Line("    (summ|summary) <message> - Print a summary doc comment");
+      Put_Line("    value <name> <message> - Print a value doc comment");
+   end Help;
 
-  function Try_Act return Boolean is
-  begin
-    if Argument_Stack.Is_Empty then goto Fail; end if;
+   function Try_Act return Boolean is
+   begin
+      if Argument_Stack.Is_Empty then goto Fail; end if;
       declare
-        Action : constant String := Argument_Stack.Pop;
+         Action : constant String := Argument_Stack.Pop;
       begin
-        if To_Upper(Action) /= "CMM" and To_Upper(Action) /= "COMMENT" then
-          goto Fail;
-        end if;
+         if To_Upper(Action) /= "CMM" and To_Upper(Action) /= "COMMENT" then
+            goto Fail;
+         end if;
       end;
-    -- We don't need to verify a target exists, because no target is a normal comment. As a result of this, we don't actually need any arguments in the stack, because we can always create an empty comment. So instead of failing, goto the creation of a basic comment
-    if Argument_Stack.Is_Empty then goto Basic_Comment; end if;
-    declare
+      -- We don't need to verify a target exists, because no target is a normal comment. As a result of this, we don't actually need any arguments in the stack, because we can always create an empty comment. So instead of failing, goto the creation of a basic comment
+      if Argument_Stack.Is_Empty then goto Basic_Comment; end if;
+      declare
       Target : constant String := Argument_Stack.Pop;
-    begin
+      begin
       if To_Upper(Target) = "DESC" or To_Upper(Target) = "DESCRIPTION" then
-        Print_Description_Comment(Argument_Stack.Pop_Remaining);
-        return True;
+         Print_Description_Comment(Argument_Stack.Pop_Remaining);
+         return True;
       elsif To_Upper(Target) = "EX" or To_Upper(Target) = "EXCEPTION" then
-        if Argument_Stack.Is_Empty then
-          Put_Line(Standard_Error, "Error: No exception name was specified");
-          goto Fail;
-        end if;
-        declare
-          Name : constant String := Argument_Stack.Pop;
-        begin
-          Print_Exception_Comment(Name, Argument_Stack.Pop_Remaining);
-          return True;
-        end;
+         if Argument_Stack.Is_Empty then
+            Put_Line(Standard_Error, "Error: No exception name was specified");
+            goto Fail;
+         end if;
+         declare
+            Name : constant String := Argument_Stack.Pop;
+         begin
+            Print_Exception_Comment(Name, Argument_Stack.Pop_Remaining);
+            return True;
+         end;
       elsif To_Upper(Target) = "FIELD" then
-        if Argument_Stack.Is_Empty then
-          Put_Line(Standard_Error, "Error: No field name was specified");
-          goto Fail;
-        end if;
-        declare
-          Name : constant String := Argument_Stack.Pop;
-        begin
-          Print_Field_Comment(Name, Argument_Stack.Pop_Remaining);
-          return True;
-        end;
+         if Argument_Stack.Is_Empty then
+            Put_Line(Standard_Error, "Error: No field name was specified");
+            goto Fail;
+         end if;
+         declare
+            Name : constant String := Argument_Stack.Pop;
+         begin
+            Print_Field_Comment(Name, Argument_Stack.Pop_Remaining);
+            return True;
+         end;
       elsif To_Upper(Target) = "PARAM" then
-        if Argument_Stack.Is_Empty then
-          Put_Line(Standard_Error, "Error: No param name was specified");
-          goto Fail;
-        end if;
-        declare
-          Name : constant String := Argument_Stack.Pop;
-        begin
-          Print_Param_Comment(Name, Argument_Stack.Pop_Remaining);
-          return True;
-        end;
+         if Argument_Stack.Is_Empty then
+            Put_Line(Standard_Error, "Error: No param name was specified");
+            goto Fail;
+         end if;
+         declare
+            Name : constant String := Argument_Stack.Pop;
+         begin
+            Print_Param_Comment(Name, Argument_Stack.Pop_Remaining);
+            return True;
+         end;
       elsif To_Upper(Target) = "RET" or To_Upper(Target) = "RETURN" then
-        Print_Return_Comment(Argument_Stack.Pop_Remaining);
-        return True;
+         Print_Return_Comment(Argument_Stack.Pop_Remaining);
+         return True;
       elsif To_Upper(Target) = "SUMM" or To_Upper(Target) = "SUMMARY" then
-        Print_Summary_Comment(Argument_Stack.Pop_Remaining);
-        return True;
+         Print_Summary_Comment(Argument_Stack.Pop_Remaining);
+         return True;
       elsif To_Upper(Target) = "VALUE" then
-        if Argument_Stack.Is_Empty then
-          Put_Line(Standard_Error, "Error: No value name was specified");
-          goto Fail;
-        end if;
-        declare
-          Name : constant String := Argument_Stack.Pop;
-        begin
-          Print_Value_Comment(Name, Argument_Stack.Pop_Remaining);
-          return True;
-        end;
+         if Argument_Stack.Is_Empty then
+            Put_Line(Standard_Error, "Error: No value name was specified");
+            goto Fail;
+         end if;
+         declare
+            Name : constant String := Argument_Stack.Pop;
+         begin
+            Print_Value_Comment(Name, Argument_Stack.Pop_Remaining);
+            return True;
+         end;
       else
-        --The "Target" was really the first word of the message, so put it back
-        Argument_Stack.Push_Back;
-        goto Basic_Comment;
+         --The "Target" was really the first word of the message, so put it back
+         Argument_Stack.Push_Back;
+         goto Basic_Comment;
       end if;
-    end;
-    <<Basic_Comment>>
-    Print_Comment(Argument_Stack.Pop_Remaining);
-    return True;
-    <<Fail>>
-    Argument_Stack.Reset;
-    return False;
-  end Try_Act;
+      end;
+      <<Basic_Comment>>
+      Print_Comment(Argument_Stack.Pop_Remaining);
+      return True;
+      <<Fail>>
+      Argument_Stack.Reset;
+      return False;
+   end Try_Act;
+
 end Actions.Comment;

--- a/src/actions-comment.ads
+++ b/src/actions-comment.ads
@@ -1,7 +1,21 @@
+-- Copyright 2019 Patrick Kelly (entomy)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 package Actions.Comment is
 
-  procedure Help;
+   procedure Help;
 
-  function Try_Act return Boolean;
+   function Try_Act return Boolean;
 
 end Actions.Comment;

--- a/src/actions-func.adb
+++ b/src/actions-func.adb
@@ -1,3 +1,17 @@
+-- Copyright 2014-2019 Simon Symeonidis (psyomn)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 with Ada.Text_IO; use Ada.Text_IO;
 with Ada.Characters.Handling; use Ada.Characters.Handling;
 with Agen; use Agen;
@@ -5,50 +19,50 @@ with Argument_Stack;
 
 package body Actions.Func is
 
-  procedure Help is
-  begin
-    Put_Line("  (func|function) name:return_type [parameter:type]* - Print the generated function");
-  end Help;
+   procedure Help is
+   begin
+      Put_Line("  (func|function) name:return_type [parameter:type]* - Print the generated function");
+   end Help;
 
-  function Try_Act return Boolean is
-    Func : Parameter;
-  begin
-    if Argument_Stack.Is_Empty then goto Fail; end if;
-    declare
+   function Try_Act return Boolean is
+      Func : Parameter;
+   begin
+      if Argument_Stack.Is_Empty then goto Fail; end if;
+      declare
       Action : constant String := Argument_Stack.Pop;
-    begin
+      begin
       if To_Upper(Action) /= "FUNC" and To_Upper(Action) /= "FUNCTION" then
-        goto Fail;
+         goto Fail;
       end if;
-    end;
-    if Argument_Stack.Is_Empty then
+      end;
+      if Argument_Stack.Is_Empty then
       Put_Line(Standard_Error, "Error: No function signature was specified");
       goto Fail;
-    end if;
-    if not Try_Parse(Argument_Stack.Pop, Func) then
+      end if;
+      if not Try_Parse(Argument_Stack.Pop, Func) then
       Put_Line(Standard_Error, "Error: The function signature was invalid");
       goto Fail;
-    end if;
-    if Argument_Stack.Is_Empty then
+      end if;
+      if Argument_Stack.Is_Empty then
       Print_Function(Func);
-    else
+      else
       declare
-        Params : Parameter_Array(1 .. Argument_Stack.Length);
+         Params : Parameter_Array(1 .. Argument_Stack.Length);
       begin
-        for I in 1 .. Argument_Stack.Length loop
-          if not Try_Parse(Argument_Stack.Pop, Params(I)) then
+         for I in 1 .. Argument_Stack.Length loop
+            if not Try_Parse(Argument_Stack.Pop, Params(I)) then
             Argument_Stack.Push_Back;
             Put_Line(Standard_Error, "Error: The parameter signature """ & Argument_Stack.Pop & """ was invalid");
             goto Fail;
-          end if;
-        end loop;
-        Print_Function(Func, Params);
+            end if;
+         end loop;
+         Print_Function(Func, Params);
       end;
-    end if;
-    return True;
-    <<Fail>>
-    Argument_Stack.Reset;
-    return False;
-  end Try_Act;
+      end if;
+      return True;
+      <<Fail>>
+      Argument_Stack.Reset;
+      return False;
+   end Try_Act;
 
 end Actions.Func;

--- a/src/actions-func.ads
+++ b/src/actions-func.ads
@@ -1,3 +1,17 @@
+-- Copyright 2019 Patrick Kelly (entomy)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 package Actions.Func is
 
   procedure Help;

--- a/src/actions-init.adb
+++ b/src/actions-init.adb
@@ -1,3 +1,17 @@
+-- Copyright 2014-2019 Simon Symeonidis (psyomn)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 with Ada.Text_IO; use Ada.Text_IO;
 with Ada.Characters.Handling; use Ada.Characters.Handling;
 with Agen; use Agen;
@@ -5,51 +19,52 @@ with Argument_Stack;
 
 package body Actions.Init is
 
-  procedure Help is
-  begin
-    Put_Line("  (new|init)");
-    Put_Line("    project <name> - create a project from a basic template");
-    Put_Line("    gpr <name> - create a GPR from a basic template");
-  end Help;
+   procedure Help is
+   begin
+      Put_Line("  (new|init)");
+      Put_Line("    project <name> - create a project from a basic template");
+      Put_Line("    gpr <name> - create a GPR from a basic template");
+   end Help;
 
-  function Try_Act return Boolean is
-  begin
-    if Argument_Stack.Is_Empty then goto Fail; end if;
-    declare
+   function Try_Act return Boolean is
+   begin
+      if Argument_Stack.Is_Empty then goto Fail; end if;
+      declare
       Action : constant String := Argument_Stack.Pop;
-    begin
+      begin
       if To_Upper(Action) /= "NEW" and To_Upper(Action) /= "INIT" then
-        goto Fail;
+         goto Fail;
       end if;
-    end;
-    if Argument_Stack.Is_Empty then
+      end;
+      if Argument_Stack.Is_Empty then
       Put_Line(Standard_Error, "Error: No target was specified");
       goto Fail;
-    end if;
-    declare
-      Target : constant String := Argument_Stack.Pop;
-    begin
-      if To_Upper(Target) = "PROJECT" then
-        if Argument_Stack.Is_Empty then
-          Put_Line(Standard_Error, "Error: No name was specifed");
-          goto Fail;
-        end if;
-        Agen.Create_Project(Argument_Stack.Pop);
-        return True;
-      elsif To_Upper(Target) = "GPR" then
-        if Argument_Stack.Is_Empty then
-          Put_Line(Standard_Error, "Error: No name was specified");
-          goto Fail;
-        end if;
-        Agen.Create_GPR(Argument_Stack.Pop);
-        return True;
-      else
-        Put_Line(Standard_Error, "Error: """ & Target & """ was not an understood target");
-        goto Fail;
       end if;
-    end;
-    <<Fail>>
-    Argument_Stack.Reset;
-    return False;
-  end Try_Act;
+      declare
+      Target : constant String := Argument_Stack.Pop;
+      begin
+      if To_Upper(Target) = "PROJECT" then
+         if Argument_Stack.Is_Empty then
+            Put_Line(Standard_Error, "Error: No name was specifed");
+            goto Fail;
+         end if;
+         Agen.Create_Project(Argument_Stack.Pop);
+         return True;
+      elsif To_Upper(Target) = "GPR" then
+         if Argument_Stack.Is_Empty then
+            Put_Line(Standard_Error, "Error: No name was specified");
+            goto Fail;
+         end if;
+         Agen.Create_GPR(Argument_Stack.Pop);
+         return True;
+      else
+         Put_Line(Standard_Error, "Error: """ & Target & """ was not an understood target");
+         goto Fail;
+      end if;
+      end;
+      <<Fail>>
+      Argument_Stack.Reset;
+      return False;
+   end Try_Act;
+
 end Actions.Init;

--- a/src/actions-init.ads
+++ b/src/actions-init.ads
@@ -1,3 +1,17 @@
+-- Copyright 2019 Patrick Kelly (entomy)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 -- This is actually "new", but that's a reserved word in Ada
 package Actions.Init is
 

--- a/src/actions-proc.adb
+++ b/src/actions-proc.adb
@@ -1,3 +1,17 @@
+-- Copyright 2014-2019 Simon Symeonidis (psyomn)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 with Ada.Text_IO; use Ada.Text_IO;
 with Ada.Characters.Handling; use Ada.Characters.Handling;
 with Agen; use Agen;
@@ -5,46 +19,46 @@ with Argument_Stack;
 
 package body Actions.Proc is
 
-  procedure Help is
-  begin
-    Put_Line("  (proc|procedure) [parameter:type]* - Print the generated procedure");
-  end Help;
+   procedure Help is
+   begin
+      Put_Line("  (proc|procedure) [parameter:type]* - Print the generated procedure");
+   end Help;
 
-  function Try_Act return Boolean is
-  begin
-    if Argument_Stack.Is_Empty then goto Fail; end if;
-    declare
+   function Try_Act return Boolean is
+   begin
+      if Argument_Stack.Is_Empty then goto Fail; end if;
+      declare
       Action : constant String := Argument_Stack.Pop;
-    begin
+      begin
       if To_Upper(Action) /= "PROC" and To_Upper(Action) /= "PROCEDURE" then
-        goto Fail;
+         goto Fail;
       end if;
-    end;
-    if Argument_Stack.Is_Empty then
+      end;
+      if Argument_Stack.Is_Empty then
       Put_Line(Standard_Error, "Error: No name was specified");
       goto Fail;
-    end if;
-    declare
+      end if;
+      declare
       Name : constant String := Argument_Stack.Pop;
       Params : Parameter_Array(1 .. Argument_Stack.Length);
-    begin
+      begin
       if Argument_Stack.Is_Empty then
-        Print_Procedure(Name);
+         Print_Procedure(Name);
       else
-        for I in 1 .. Argument_Stack.Length loop
-          if not Try_Parse(Argument_Stack.Pop, Params(I)) then
+         for I in 1 .. Argument_Stack.Length loop
+            if not Try_Parse(Argument_Stack.Pop, Params(I)) then
             Argument_Stack.Push_Back;
             Put_Line(Standard_Error, "Error: The parameter signature """ & Argument_Stack.Pop & """ was invalid");
             goto Fail;
-          end if;
-        end loop;
-        Print_Procedure(Name, Params);
+            end if;
+         end loop;
+         Print_Procedure(Name, Params);
       end if;
-    end;
-    return True;
-    <<Fail>>
-    Argument_Stack.Reset;
-    return False;
-  end Try_Act;
+      end;
+      return True;
+      <<Fail>>
+      Argument_Stack.Reset;
+      return False;
+   end Try_Act;
 
 end Actions.Proc;

--- a/src/actions-proc.ads
+++ b/src/actions-proc.ads
@@ -1,7 +1,21 @@
+-- Copyright 2019 Patrick Kelly (entomy)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 package Actions.Proc is
 
-  procedure Help;
+   procedure Help;
 
-  function Try_Act return Boolean;
+   function Try_Act return Boolean;
 
 end Actions.Proc;

--- a/src/actions.ads
+++ b/src/actions.ads
@@ -1,2 +1,17 @@
+-- Copyright 2019 Patrick Kelly (entomy)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+
 package Actions is
 end Actions;

--- a/src/agen.adb
+++ b/src/agen.adb
@@ -1,3 +1,18 @@
+-- Copyright 2014-2019 Simon Symeonidis (psyomn), Patrick Kelly (entomy)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+
 with Ada.Text_IO; use Ada.Text_IO;
 with Ada.Characters.Handling; use Ada.Characters.Handling;
 with Ada.Directories; use Ada.Directories;

--- a/src/agen.adb
+++ b/src/agen.adb
@@ -1,17 +1,3 @@
--- Copyright 2014-2019 Simon Symeonidis (psyomn)
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---   http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
-
 with Ada.Text_IO; use Ada.Text_IO;
 with Ada.Characters.Handling; use Ada.Characters.Handling;
 with Ada.Directories; use Ada.Directories;
@@ -187,8 +173,16 @@ package body Agen is
   end Print_Value_Comment;
 
   procedure Print_Procedure(Name : String) is
+  begin
+    Print_Procedure(Name, False);
+  end Print_Procedure;
+
+  procedure Print_Procedure(Name : String; Stub_Comments : Boolean) is
     Sanitized_Name : constant String := Sanitize_Name(Name);
   begin
+    if Stub_Comments then
+      Print_Comment("Summary of " & Name);
+    end if;
     Put_Line("procedure " & Sanitized_Name & " is");
     Put_Line("begin");
     New_Line;
@@ -196,8 +190,17 @@ package body Agen is
   end Print_Procedure;
 
   procedure Print_Procedure(Name : String; Param : Parameter) is
+  begin
+    Print_Procedure(Name, Param, False);
+  end Print_Procedure;
+
+  procedure Print_Procedure(Name : String; Param : Parameter; Stub_Comments : Boolean) is
     Sanitized_Name : constant String := Sanitize_Name(Name);
   begin
+    if Stub_Comments then
+      Print_Comment("Summary of " & Name);
+      Print_Param_Comment(To_String(Param.Name), "Summary of " & To_String(Param.Name));
+    end if;
     Put_Line("procedure " & Sanitized_Name & "(" & To_String(Param.Name) & " : " & To_String(Param.Of_Type) & ") is");
     Put_Line("begin");
     New_Line;
@@ -205,8 +208,19 @@ package body Agen is
   end Print_Procedure;
 
   procedure Print_Procedure(Name : String; Params : Parameter_Array) is
+  begin
+    Print_Procedure(Name, Params, False);
+  end Print_Procedure;
+
+  procedure Print_Procedure(Name : String; Params : Parameter_Array; Stub_Comments : Boolean) is
     Sanitized_Name : constant String := Sanitize_Name(Name);
   begin
+    if Stub_Comments then
+      Print_Comment("Summary of " & Name);
+      for Param of Params loop
+        Print_Param_Comment(To_String(Param.Name), "Summary of " & To_String(Param.Name));
+      end loop;
+    end if;
     Put("procedure " & Sanitized_Name & "(");
     for I in 1 .. Params'Length - 1 loop
       Put(To_String(Params(I).Name) & " : " & To_String(Params(Params'Last).Of_Type) & "; ");
@@ -219,12 +233,26 @@ package body Agen is
 
   procedure Print_Function(Form : Parameter) is
   begin
-    Print_Function(To_String(Form.Name), To_String(Form.Of_Type));
+    Print_Function(Form, False);
+  end Print_Function;
+
+  procedure Print_Function(Form : Parameter; Stub_Comments : Boolean) is
+  begin
+    Print_Function(To_String(Form.Name), To_String(Form.Of_Type), Stub_Comments);
   end Print_Function;
 
   procedure Print_Function(Name : String; Returns : String) is
+  begin
+    Print_Function(Name, Returns, False);
+  end Print_Function;
+
+  procedure Print_Function(Name : String; Returns : String; Stub_Comments : Boolean) is
     Sanitized_Name : constant String := Sanitize_Name(Name);
   begin
+    if Stub_Comments then
+      Print_Comment("Summary of " & Name);
+      Print_Return_Comment("Summary of return value");
+    end if;
     Put_Line("function " & Sanitized_Name & " return " & Returns & " is");
     Put_Line("begin");
     New_Line;
@@ -233,12 +261,27 @@ package body Agen is
 
   procedure Print_Function(Form : Parameter; Param : Parameter) is
   begin
-    Print_Function(To_String(Form.Name), To_String(Form.Of_Type), Param);
+    Print_Function(Form, Param, False);
+  end Print_Function;
+
+  procedure Print_Function(Form : Parameter; Param : Parameter; Stub_Comments : Boolean) is
+  begin
+    Print_Function(To_String(Form.Name), To_String(Form.Of_Type), Param, Stub_Comments);
   end Print_Function;
 
   procedure Print_Function(Name : String; Returns : String; Param : Parameter) is
+  begin
+    Print_Function(Name, Returns, Param, False);
+  end Print_Function;
+
+  procedure Print_Function(Name : String; Returns : String; Param : Parameter; Stub_Comments : Boolean) is
     Sanitized_Name : constant String := Sanitize_Name(Name);
   begin
+    if Stub_Comments then
+      Print_Comment("Summary of " & Name);
+      Print_Param_Comment(To_String(Param.Name), "Summary of " & To_String(Param.Name));
+      Print_Return_Comment("Summary of return value");
+    end if;
     Put_Line("function " & Sanitized_Name & "(" & To_String(Param.Name) & " : " & To_String(Param.Of_Type) & ") return " & Returns & " is");
     Put_Line("begin");
     New_Line;
@@ -247,12 +290,29 @@ package body Agen is
 
   procedure Print_Function(Form : Parameter; Params : Parameter_Array) is
   begin
-    Print_Function(To_String(Form.Name), To_String(Form.Of_Type), Params);
+    Print_Function(Form, Params, False);
+  end Print_Function;
+
+  procedure Print_Function(Form : Parameter; Params : Parameter_Array; Stub_Comments : Boolean) is
+  begin
+    Print_Function(To_String(Form.Name), To_String(Form.Of_Type), Params, Stub_Comments);
   end Print_Function;
 
   procedure Print_Function(Name : String; Returns : String; Params : Parameter_Array) is
+  begin
+    Print_Function(Name, Returns, Params, False);
+  end Print_Function;
+
+  procedure Print_Function(Name : String; Returns : String; Params : Parameter_Array; Stub_Comments : Boolean) is
     Sanitized_Name : constant String := Sanitize_Name(Name);
   begin
+    if Stub_Comments then
+      Print_Comment("Summary of " & Name);
+      for Param of Params loop
+        Print_Param_Comment(To_String(Param.Name), "Summary of " & To_String(Param.Name));
+      end loop;
+      Print_Return_Comment("Summary of return value");
+    end if;
     Put("function " & Sanitized_Name & "(");
     -- Iterate through all but the last parameter, which is printed differently
     for I in 1 .. Params'Length - 1 loop

--- a/src/agen.adb
+++ b/src/agen.adb
@@ -57,7 +57,8 @@ package body Agen is
 
   procedure Create_Project(Name : String) is
   begin
-    Put("Creating Project...");
+    Put_Line("Creating Project...");
+    
     -- Create root directory
     Create_Directory(Name);
 

--- a/src/agen.ads
+++ b/src/agen.ads
@@ -1,17 +1,3 @@
--- Copyright 2014-2019 Simon Symeonidis (psyomn)
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---   http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
-
 with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 
 package Agen is
@@ -54,21 +40,39 @@ package Agen is
 
   procedure Print_Procedure(Name : String);
 
+  procedure Print_Procedure(Name : String; Stub_Comments : Boolean);
+
   procedure Print_Procedure(Name : String; Param : Parameter);
+
+  procedure Print_Procedure(Name : String; Param : Parameter; Stub_Comments : Boolean);
 
   procedure Print_Procedure(Name : String; Params : Parameter_Array);
 
+  procedure Print_Procedure(Name : String; Params : Parameter_Array; Stub_Comments : Boolean);
+
   procedure Print_Function(Form : Parameter);
+
+  procedure Print_Function(Form : Parameter; Stub_Comments : Boolean);
 
   procedure Print_Function(Name : String; Returns : String);
 
+  procedure Print_Function(Name : String; Returns : String; Stub_Comments : Boolean);
+
   procedure Print_Function(Form : Parameter; Param : Parameter);
+
+  procedure Print_Function(Form : Parameter; Param : Parameter; Stub_Comments : Boolean);
 
   procedure Print_Function(Name : String; Returns : String; Param : Parameter);
 
+  procedure Print_Function(Name : String; Returns : String; Param : Parameter; Stub_Comments : Boolean);
+
   procedure Print_Function(Form : Parameter; Params : Parameter_Array);
 
+  procedure Print_Function(Form : Parameter; Params : Parameter_Array; Stub_Comments : Boolean);
+
   procedure Print_Function(Name : String; Returns : String; Params : Parameter_Array);
+
+  procedure Print_Function(Name : String; Returns : String; Params : Parameter_Array; Stub_Comments : Boolean);
 
 private
   type Parameter is record

--- a/src/agen.ads
+++ b/src/agen.ads
@@ -1,3 +1,18 @@
+-- Copyright 2014-2019 Simon Symeonidis (psyomn), Patrick Kelly (entomy)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+
 with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 
 package Agen is

--- a/src/argument_stack.adb
+++ b/src/argument_stack.adb
@@ -1,35 +1,49 @@
+-- Copyright 2019 Patrick Kelly (entomy)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 with Ada.Command_Line; use Ada.Command_Line;
 with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 
 package body Argument_Stack is
 
-  function Is_Empty return Boolean is (Current > Argument_Count);
+   function Is_Empty return Boolean is (Current > Argument_Count);
 
-  function Length return Natural is ((Argument_Count + 1) - Current);
+   function Length return Natural is ((Argument_Count + 1) - Current);
 
-  procedure Reset is
-  begin
-    Current := 1;
-  end Reset;
+   procedure Reset is
+   begin
+      Current := 1;
+   end Reset;
 
-  procedure Push_Back is
-  begin
-    Current := Current - 1;
-  end Push_Back;
+   procedure Push_Back is
+   begin
+      Current := Current - 1;
+   end Push_Back;
 
-  function Pop return String is
-  begin
-    Current := Current + 1;
-    return Argument(Current - 1);
-  end Pop;
+   function Pop return String is
+   begin
+      Current := Current + 1;
+      return Argument(Current - 1);
+   end Pop;
 
-  function Pop_Remaining return String is
-    Result : Unbounded_String;
-  begin
-    while not Is_Empty loop
+   function Pop_Remaining return String is
+      Result : Unbounded_String;
+   begin
+      while not Is_Empty loop
       Append(Result, Pop & " ");
-    end loop;
-    return To_String(Result);
-  end Pop_Remaining;
+      end loop;
+      return To_String(Result);
+   end Pop_Remaining;
 
 end Argument_Stack;

--- a/src/argument_stack.ads
+++ b/src/argument_stack.ads
@@ -1,25 +1,39 @@
+-- Copyright 2019 Patrick Kelly (entomy)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 --@summary Provides argument stack semantics
 --@description Doesn't actually implement a stack, but exposes Ada.Command_Line as a stack, because those semantics are useful
 package Argument_Stack with Preelaborate is
 
-  -----------
-  -- Stack --
-  -----------
-  --This is implemented as an "abstract state machine" or singleton because when would you actually have multiple arguments to parse?
+   -----------
+   -- Stack --
+   -----------
+   --This is implemented as an "abstract state machine" or singleton because when would you actually have multiple arguments to parse?
 
-  function Is_Empty return Boolean with Inline; --Whether the argument stack is empty.
+   function Is_Empty return Boolean with Inline; --Whether the argument stack is empty.
 
-  function Length return Natural with Inline; --Length of the stack, the amount of arguments in it.
+   function Length return Natural with Inline; --Length of the stack, the amount of arguments in it.
 
-  procedure Reset with Inline; --Reset the stack to its original state
+   procedure Reset with Inline; --Reset the stack to its original state
 
-  procedure Push_Back; --"Push" back onto the stack. This doesn't need a value because technically it just adjusts an index and the value was always there.
+   procedure Push_Back; --"Push" back onto the stack. This doesn't need a value because technically it just adjusts an index and the value was always there.
 
-  function Pop return String; --Pop the value off the stack.
+   function Pop return String; --Pop the value off the stack.
 
-  function Pop_Remaining return String; --Pop the remaining items off the stack as one single string
+   function Pop_Remaining return String; --Pop the remaining items off the stack as one single string
 
 private
-  Current : Positive := 1;
+   Current : Positive := 1;
 
 end Argument_Stack;

--- a/src/main.adb
+++ b/src/main.adb
@@ -11,6 +11,7 @@
 -- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
+
 with Ada.Text_IO; use Ada.Text_IO;
 with Actions.Comment;
 with Actions.Func;

--- a/tests.gpr
+++ b/tests.gpr
@@ -2,7 +2,7 @@ project Tests is
 
   for Main use ("agentests.adb");
   for Source_Dirs use ("src/**", "Generics/**", "Testing/**", "tests/**");
-  for Exec_Dir use "tests/";
+  for Exec_Dir use "bin/";
 
   for Object_Dir use "obj/debug";
 
@@ -11,5 +11,10 @@ project Tests is
   package Compiler is
 	for Switches ("Ada") use ("-g", "-gnatwa");
   end Compiler;
+
+  package Naming is
+    for Spec ("Generics.Testing") use "Generics.Testing.ads";
+    for Body ("Generics.Testing") use "Generics.Testing.adb";
+  end Naming;
 
 end Tests;

--- a/tests.gpr
+++ b/tests.gpr
@@ -15,6 +15,8 @@ project Tests is
   package Naming is
     for Spec ("Generics.Testing") use "Generics.Testing.ads";
     for Body ("Generics.Testing") use "Generics.Testing.adb";
+    for Spec ("Testing.Directories") use "Testing.Directories.ads";
+    for Body ("Testing.Directories") use "Testing.Directories.adb";
   end Naming;
 
 end Tests;

--- a/tests.gpr
+++ b/tests.gpr
@@ -1,8 +1,10 @@
 project Tests is
 
-  for main use "agentests.adb";
+  for Main use ("agentests.adb");
   for Source_Dirs use ("src/**", "Generics/**", "Testing/**", "tests/**");
   for Exec_Dir use "tests/";
+
+  for Object_Dir use "obj/debug";
 
   for Ignore_Source_Sub_Dirs use (".git/");
 

--- a/tests.gpr
+++ b/tests.gpr
@@ -1,0 +1,13 @@
+project Tests is
+
+  for main use "agentests.adb";
+  for Source_Dirs use ("src/**", "Generics/**", "Testing/**", "tests/**");
+  for Exec_Dir use "tests/";
+
+  for Ignore_Source_Sub_Dirs use (".git/");
+
+  package Compiler is
+	for Switches ("Ada") use ("-g", "-gnatwa");
+  end Compiler;
+
+end Tests;

--- a/tests/agen-testing.adb
+++ b/tests/agen-testing.adb
@@ -1,0 +1,46 @@
+with Ada.Text_IO, Ada.Wide_Wide_Text_IO, Testing;
+use Ada.Wide_Wide_Text_IO, Testing;
+
+package body Agen.Testing is
+
+  ---------------
+  -- Parameter --
+  ---------------
+
+  procedure Is_Equal(Statement : Wide_Wide_String; Result : in Parameter; Expected_Name, Expected_Type : String) is
+  begin
+		if To_String(Result.Name) = Expected_Name and then To_String(Result.Of_Type) = Expected_Type then
+			Pass;
+		else
+			Fail;
+		end if;
+		Put(Statement & " → Name: ");
+		Ada.Text_IO.Put(To_String(Result.Name));
+		Put(" = """);
+		Ada.Text_IO.Put(Expected_Name);
+		Put(""" Type: ");
+		Ada.Text_IO.Put(To_String(Result.Of_Type));
+		Put(" = """);
+		Ada.Text_IO.Put(Expected_Type);
+		Put("""");
+  end Is_Equal;
+
+  procedure Is_Not_Equal(Statement : Wide_Wide_String; Result : in Parameter; Expected_Name, Expected_Type : String) is
+  begin
+		if To_String(Result.Name) /= Expected_Name and then To_String(Result.Of_Type) /= Expected_Type then
+			Pass;
+		else
+			Fail;
+		end if;
+		Put(Statement & " → Name: ");
+		Ada.Text_IO.Put(To_String(Result.Name));
+		Put(" ≠ """);
+		Ada.Text_IO.Put(Expected_Name);
+		Put(""" Type: ");
+		Ada.Text_IO.Put(To_String(Result.Of_Type));
+		Put(" ≠ """);
+		Ada.Text_IO.Put(Expected_Type);
+		Put("""");
+  end Is_Not_Equal;
+
+end Agen.Testing;

--- a/tests/agen-testing.adb
+++ b/tests/agen-testing.adb
@@ -37,6 +37,7 @@ package body Agen.Testing is
       Put(" = """);
       Ada.Text_IO.Put(Expected_Type);
       Put("""");
+      New_Line;
    end Is_Equal;
 
    procedure Is_Not_Equal(Statement : Wide_Wide_String; Result : in Parameter; Expected_Name, Expected_Type : String) is
@@ -55,6 +56,7 @@ package body Agen.Testing is
       Put(" ≠ """);
       Ada.Text_IO.Put(Expected_Type);
       Put("""");
+      New_Line;
    end Is_Not_Equal;
 
 end Agen.Testing;

--- a/tests/agen-testing.adb
+++ b/tests/agen-testing.adb
@@ -1,46 +1,60 @@
+-- Copyright 2019 Patrick Kelly (entomy)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 with Ada.Text_IO, Ada.Wide_Wide_Text_IO, Testing;
 use Ada.Wide_Wide_Text_IO, Testing;
 
 package body Agen.Testing is
 
-  ---------------
-  -- Parameter --
-  ---------------
+   ---------------
+   -- Parameter --
+   ---------------
 
-  procedure Is_Equal(Statement : Wide_Wide_String; Result : in Parameter; Expected_Name, Expected_Type : String) is
-  begin
-		if To_String(Result.Name) = Expected_Name and then To_String(Result.Of_Type) = Expected_Type then
-			Pass;
-		else
-			Fail;
-		end if;
-		Put(Statement & " → Name: ");
-		Ada.Text_IO.Put(To_String(Result.Name));
-		Put(" = """);
-		Ada.Text_IO.Put(Expected_Name);
-		Put(""" Type: ");
-		Ada.Text_IO.Put(To_String(Result.Of_Type));
-		Put(" = """);
-		Ada.Text_IO.Put(Expected_Type);
-		Put("""");
-  end Is_Equal;
+   procedure Is_Equal(Statement : Wide_Wide_String; Result : in Parameter; Expected_Name, Expected_Type : String) is
+   begin
+      if To_String(Result.Name) = Expected_Name and then To_String(Result.Of_Type) = Expected_Type then
+         Pass;
+      else
+         Fail;
+      end if;
+      Put(Statement & " → Name: ");
+      Ada.Text_IO.Put(To_String(Result.Name));
+      Put(" = """);
+      Ada.Text_IO.Put(Expected_Name);
+      Put(""" Type: ");
+      Ada.Text_IO.Put(To_String(Result.Of_Type));
+      Put(" = """);
+      Ada.Text_IO.Put(Expected_Type);
+      Put("""");
+   end Is_Equal;
 
-  procedure Is_Not_Equal(Statement : Wide_Wide_String; Result : in Parameter; Expected_Name, Expected_Type : String) is
-  begin
-		if To_String(Result.Name) /= Expected_Name and then To_String(Result.Of_Type) /= Expected_Type then
-			Pass;
-		else
-			Fail;
-		end if;
-		Put(Statement & " → Name: ");
-		Ada.Text_IO.Put(To_String(Result.Name));
-		Put(" ≠ """);
-		Ada.Text_IO.Put(Expected_Name);
-		Put(""" Type: ");
-		Ada.Text_IO.Put(To_String(Result.Of_Type));
-		Put(" ≠ """);
-		Ada.Text_IO.Put(Expected_Type);
-		Put("""");
-  end Is_Not_Equal;
+   procedure Is_Not_Equal(Statement : Wide_Wide_String; Result : in Parameter; Expected_Name, Expected_Type : String) is
+   begin
+      if To_String(Result.Name) /= Expected_Name and then To_String(Result.Of_Type) /= Expected_Type then
+         Pass;
+      else
+         Fail;
+      end if;
+      Put(Statement & " → Name: ");
+      Ada.Text_IO.Put(To_String(Result.Name));
+      Put(" ≠ """);
+      Ada.Text_IO.Put(Expected_Name);
+      Put(""" Type: ");
+      Ada.Text_IO.Put(To_String(Result.Of_Type));
+      Put(" ≠ """);
+      Ada.Text_IO.Put(Expected_Type);
+      Put("""");
+   end Is_Not_Equal;
 
 end Agen.Testing;

--- a/tests/agen-testing.ads
+++ b/tests/agen-testing.ads
@@ -1,12 +1,26 @@
+-- Copyright 2019 Patrick Kelly (entomy)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 -- Certain types are rightfully private but need their fields tested. Those fields should not actually be exposed through functions. This allows us to still test those while keeping the API visibility what it should be.
 package Agen.Testing is
 
-  ---------------
-  -- Parameter --
-  ---------------
+   ---------------
+   -- Parameter --
+   ---------------
 
-  procedure Is_Equal(Statement : Wide_Wide_String; Result : in Parameter; Expected_Name, Expected_Type : String);
+   procedure Is_Equal(Statement : Wide_Wide_String; Result : in Parameter; Expected_Name, Expected_Type : String);
 
-  procedure Is_Not_Equal(Statement : Wide_Wide_String; Result : in Parameter; Expected_Name, Expected_Type : String);
+   procedure Is_Not_Equal(Statement : Wide_Wide_String; Result : in Parameter; Expected_Name, Expected_Type : String);
 
 end Agen.Testing;

--- a/tests/agen-testing.ads
+++ b/tests/agen-testing.ads
@@ -1,0 +1,12 @@
+-- Certain types are rightfully private but need their fields tested. Those fields should not actually be exposed through functions. This allows us to still test those while keeping the API visibility what it should be.
+package Agen.Testing is
+
+  ---------------
+  -- Parameter --
+  ---------------
+
+  procedure Is_Equal(Statement : Wide_Wide_String; Result : in Parameter; Expected_Name, Expected_Type : String);
+
+  procedure Is_Not_Equal(Statement : Wide_Wide_String; Result : in Parameter; Expected_Name, Expected_Type : String);
+
+end Agen.Testing;

--- a/tests/agentests.adb
+++ b/tests/agentests.adb
@@ -14,6 +14,7 @@
 
 with Agen; use Agen;
 with Testing; use Testing;
+with Testing.Directories; use Testing.Directories;
 with Agen.Testing; use Agen.Testing;
 
 procedure AgenTests is
@@ -33,6 +34,8 @@ begin
       Is_Equal("Try_Parse(""name"")", Try_Parse("name", Param), False);
       Is_Equal("Parameter", Param, "name", "");
    end;
+
+   Create_Project("dummy");
 
    Testing.Stop;
 end AgenTests;

--- a/tests/agentests.adb
+++ b/tests/agentests.adb
@@ -12,10 +12,12 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+with Ada.Directories; use Ada.Directories;
 with Agen; use Agen;
 with Testing; use Testing;
 with Testing.Directories; use Testing.Directories;
 with Agen.Testing; use Agen.Testing;
+with GNAT.OS_Lib; use GNAT.OS_Lib;
 
 procedure AgenTests is
 begin
@@ -35,7 +37,20 @@ begin
       Is_Equal("Parameter", Param, "name", "");
    end;
 
-   Create_Project("dummy");
+   declare
+      Name : constant String := "dummy";
+   begin
+      Create_Project(Name);
+      Directory_Exists(Name);
+      Directory_Exists(Name & Directory_Separator & "obj");
+      Directory_Exists(Name & Directory_Separator & "obj" & Directory_Separator & "debug");
+      Directory_Exists(Name & Directory_Separator & "obj" & Directory_Separator & "release");
+      Directory_Exists(Name & Directory_Separator & "src");
+      Directory_Exists(Name & Directory_Separator & "bin");
+      File_Exists(Name & Directory_Separator & Name & ".gpr");
+      File_Exists(Name & Directory_Separator & "main.adb");
+      Delete_Tree(Name); --Cleans up afterwards
+   end;
 
    Testing.Stop;
 end AgenTests;

--- a/tests/agentests.adb
+++ b/tests/agentests.adb
@@ -1,24 +1,38 @@
+-- Copyright 2019 Patrick Kelly (entomy)
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 with Agen; use Agen;
 with Testing; use Testing;
 with Agen.Testing; use Agen.Testing;
 
 procedure AgenTests is
 begin
-	Testing.Start("Agen");
+   Testing.Start("Agen");
 
-	declare
-		Param : Parameter;
-	begin
-		Is_Equal("Try_Parse(""name:string"")", Try_Parse("name:string", Param), True);
-		Is_Equal("Parameter", Param, "name", "string");
-	end;
+   declare
+      Param : Parameter;
+   begin
+      Is_Equal("Try_Parse(""name:string"")", Try_Parse("name:string", Param), True);
+      Is_Equal("Parameter", Param, "name", "string");
+   end;
 
-	declare
-		Param : Parameter;
-	begin
-		Is_Equal("Try_Parse(""name"")", Try_Parse("name", Param), False);
-		Is_Equal("Parameter", Param, "name", "");
-	end;
+   declare
+      Param : Parameter;
+   begin
+      Is_Equal("Try_Parse(""name"")", Try_Parse("name", Param), False);
+      Is_Equal("Parameter", Param, "name", "");
+   end;
 
-	Testing.Stop;
+   Testing.Stop;
 end AgenTests;

--- a/tests/agentests.adb
+++ b/tests/agentests.adb
@@ -1,0 +1,24 @@
+with Agen; use Agen;
+with Testing; use Testing;
+with Agen.Testing; use Agen.Testing;
+
+procedure AgenTests is
+begin
+	Testing.Start("Agen");
+
+	declare
+		Param : Parameter;
+	begin
+		Is_Equal("Try_Parse(""name:string"")", Try_Parse("name:string", Param), True);
+		Is_Equal("Parameter", Param, "name", "string");
+	end;
+
+	declare
+		Param : Parameter;
+	begin
+		Is_Equal("Try_Parse(""name"")", Try_Parse("name", Param), False);
+		Is_Equal("Parameter", Param, "name", "");
+	end;
+
+	Testing.Stop;
+end AgenTests;


### PR DESCRIPTION
When I did some restructuring I removed comment stubs as this should be optional behavior. This reintroduces those stubs through overloads with a Boolean parameter for the `Print_Function` and `Print_Procedure` routines. (I specifically did not implement these as default parameters because the value is inserted in the calling code, which causes some well documented maintainability problems). This isn't currently callable from the command line as I need to work out a good method of getting flags out of the command line when certain actions also eat the entire command line args.

Additionally I've added a very basic unit test. I chose to go with my own framework as overwhelming Agen is doing a lot of stuff that isn't typically testable or easily testable with the common "compare value against function call result" approach. There's two major issues. Certain things like the `Parameter` type shouldn't expose their fields publicly. Because of the approach JUnit style tests take, it would have to be public to be callable. Adding addition code only to the public API only to support unit tests is not a good idea, imo. Because of the approach Testing takes an assertion can be created through a child package which can still see, and therefore compare, these private fields without exposing them. Also given the large amount of console I/O and file generation, testing for these is typically quite awkward. I can add the necessary extensions to support this to my framework far quicker than I could add them to AUnit.