### PR TITLE
Factored function and procedure comment stub generators out, and updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ $ agen fn funcname:string param1:string param2:int
 
 Which will yield:
 ~~~~ada
--- @author simon
 -- @param world
 function hello(world : string) return string is
 begin
@@ -64,7 +63,6 @@ $ agen proc myproc param1:int
 and yield the following results:
 
 ~~~~ada
--- @author simon
 -- @param param1
 procedure myproc(param1 : int) is
 -- Enter your contents here...
@@ -87,7 +85,6 @@ $ agen cmm fn funcname:string param1:int param2:int
 and will yield:
 
 ~~~~bash
--- @author simon
 -- @param param1
 -- @param param2
 -- @return

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ gnatmake _(.gpr)_ file. Once you're there, run the following:
 ~~~~bash
 gnatmake -P agen -p
 ~~~~
+or
+~~~~bash
+gprbuild -P agen -p
+~~~~
 
 #### Commands
 
@@ -27,22 +31,20 @@ project.
 
 If you want to generate the code for a function:
 ~~~~bash
-$ agen print function funcname:string param1:string param2:int
+$ agen function funcname:string param1:string param2:int
 ~~~~
 
 or the shorter equivalent:
 
 ~~~~bash
-$ agen p fn funcname:string param1:string param2:int
+$ agen fn funcname:string param1:string param2:int
 ~~~~
 
 Which will yield:
 ~~~~ada
 -- @author simon
 -- @param world
--- @date 2014-04-16 (iso)
 function hello(world : string) return string is
--- Enter your contents here...
 begin
 end hello;
 ~~~~
@@ -50,13 +52,13 @@ end hello;
 Generating code for a procedure is similar:
 
 ~~~~bash
-$ agen print procedure myproc param1:int
+$ agen procedure myproc param1:int
 ~~~~
 
 or the shorter equivalent:
 
 ~~~~bash
-$ agen p proc myproc param1:int
+$ agen proc myproc param1:int
 ~~~~
 
 and yield the following results:
@@ -64,29 +66,29 @@ and yield the following results:
 ~~~~ada
 -- @author simon
 -- @param param1
--- @date 2014-04-16 (iso)
 procedure myproc(param1 : int) is
 -- Enter your contents here...
 begin
 end myproc;
 ~~~~
 
-Notice that you don't need to specify a return for the proc, in the command.
-You could provide one, but it would be ignored.
-
 You can also quickly generate comments. For example if you want to document
 a function that was not previously documented, you can enter the parameters
 in the following command:
 
 ~~~~bash
-$ agen p cmm param1:int param2:int
+$ agen comment function funcname:string param1:int param2:int
+~~~~
+or
+~~~~bash
+$ agen cmm fn funcname:string param1:int param2:int
 ~~~~
 
-and yield:
+and will yield:
 
 ~~~~bash
 -- @author simon
 -- @param param1
 -- @param param2
--- @date 2014-04-16 (iso)
+-- @return
 ~~~~

--- a/src/actions-comment.adb
+++ b/src/actions-comment.adb
@@ -114,6 +114,29 @@ package body Actions.Comment is
             Print_Param_Comment(Name, Argument_Stack.Pop_Remaining);
             return True;
          end;
+      elsif To_Upper(Target) = "PROC" or To_Upper(Target) = "PROCEDURE" then
+         if Argument_Stack.Is_Empty then
+            Put_Line(Standard_Error, "Error: No name was specified");
+            goto Fail;
+         end if;
+         declare
+            Name : constant String := Argument_Stack.Pop;
+            Params : Parameter_Array(1 .. Argument_Stack.Length);
+         begin
+            if Argument_Stack.Is_Empty then
+               Print_Procedure_Comment(Name);
+            else
+               for I in 1 .. Argument_Stack.Length loop
+                  if not Try_Parse(Argument_Stack.Pop, Params(I)) then
+                     Argument_Stack.Push_Back;
+                     Put_Line(Standard_Error, "Error: The parameter signature """ & Argument_Stack.Pop & """ was invalid");
+                     goto Fail;
+                  end if;
+               end loop;
+               Print_Procedure_Comment(Name, Params);
+            end if;
+         end;
+         return True;
       elsif To_Upper(Target) = "RET" or To_Upper(Target) = "RETURN" then
          Print_Return_Comment(Argument_Stack.Pop_Remaining);
          return True;

--- a/src/actions-comment.adb
+++ b/src/actions-comment.adb
@@ -25,7 +25,9 @@ package body Actions.Comment is
       Put_Line("    (desc|description) <message> - Print a description doc comment");
       Put_Line("    (ex|exception) <name> <mesage> - Print an exception doc comment");
       Put_Line("    field <name> <message> - Print a field doc comment");
+      Put_Line("    (function|fn) name:return_type [parameter:type]* - Prints a set of function doc comments");
       Put_Line("    param <name> <message> - Print a param doc comment");
+      Put_Line("    (procedure|proc) name [parameter:type]* - Prints a set of procedure doc comments");
       Put_Line("    (ret|return) <message> - Prints a return doc comment");
       Put_Line("    (summ|summary) <message> - Print a summary doc comment");
       Put_Line("    value <name> <message> - Print a value doc comment");
@@ -69,6 +71,36 @@ package body Actions.Comment is
             Name : constant String := Argument_Stack.Pop;
          begin
             Print_Field_Comment(Name, Argument_Stack.Pop_Remaining);
+            return True;
+         end;
+      elsif To_Upper(Target) = "FUNCTION" or To_Upper(Target) = "FN" then
+         declare
+            Func : Parameter;
+         begin
+            if Argument_Stack.Is_Empty then
+               Put_Line(Standard_Error, "Error: no function signature was specified");
+               goto Fail;
+            end if;
+            if not Try_Parse(Argument_Stack.Pop, Func) then
+               Put_Line(Standard_Error, "Error: The function signature was invalid");
+               goto Fail;
+            end if;
+            if Argument_Stack.Is_Empty then
+               Print_Function_Comment(Func);
+            else
+               declare
+                  Params : Parameter_Array(1 .. Argument_Stack.Length);
+               begin
+               for I in 1 .. Argument_Stack.Length loop
+                  if not Try_Parse(Argument_Stack.Pop, Params(I)) then
+                     Argument_Stack.Push_Back;
+                     Put_Line(Standard_Error, "Error: The parameter signature """ & Argument_Stack.Pop & """ was invalid");
+                     goto Fail;
+                  end if;
+               end loop;
+               Print_Function_Comment(Func, Params);
+               end;
+            end if;
             return True;
          end;
       elsif To_Upper(Target) = "PARAM" then

--- a/src/actions-func.adb
+++ b/src/actions-func.adb
@@ -46,18 +46,18 @@ package body Actions.Func is
       if Argument_Stack.Is_Empty then
          Print_Function(Func);
       else
-      declare
-         Params : Parameter_Array(1 .. Argument_Stack.Length);
-      begin
-         for I in 1 .. Argument_Stack.Length loop
-            if not Try_Parse(Argument_Stack.Pop, Params(I)) then
-            Argument_Stack.Push_Back;
-            Put_Line(Standard_Error, "Error: The parameter signature """ & Argument_Stack.Pop & """ was invalid");
-            goto Fail;
-            end if;
-         end loop;
-         Print_Function(Func, Params);
-      end;
+         declare
+            Params : Parameter_Array(1 .. Argument_Stack.Length);
+         begin
+            for I in 1 .. Argument_Stack.Length loop
+               if not Try_Parse(Argument_Stack.Pop, Params(I)) then
+               Argument_Stack.Push_Back;
+               Put_Line(Standard_Error, "Error: The parameter signature """ & Argument_Stack.Pop & """ was invalid");
+               goto Fail;
+               end if;
+            end loop;
+            Print_Function(Func, Params);
+         end;
       end if;
       return True;
       <<Fail>>

--- a/src/actions-func.adb
+++ b/src/actions-func.adb
@@ -36,15 +36,15 @@ package body Actions.Func is
       end if;
       end;
       if Argument_Stack.Is_Empty then
-      Put_Line(Standard_Error, "Error: No function signature was specified");
-      goto Fail;
+         Put_Line(Standard_Error, "Error: No function signature was specified");
+         goto Fail;
       end if;
       if not Try_Parse(Argument_Stack.Pop, Func) then
-      Put_Line(Standard_Error, "Error: The function signature was invalid");
-      goto Fail;
+         Put_Line(Standard_Error, "Error: The function signature was invalid");
+         goto Fail;
       end if;
       if Argument_Stack.Is_Empty then
-      Print_Function(Func);
+         Print_Function(Func);
       else
       declare
          Params : Parameter_Array(1 .. Argument_Stack.Length);

--- a/src/agen.adb
+++ b/src/agen.adb
@@ -168,10 +168,51 @@ package body Agen is
     Put_Line("--@field " & Name & " " & Message);
   end Print_Field_Comment;
 
+  procedure Print_Function_Comment(Name : String) is
+  begin
+    Print_Comment("Summary of " & Name);
+    Print_Return_Comment("Summary of return value");
+  end Print_Function_Comment;
+
+  procedure Print_Function_Comment(Name : String; Param : Parameter) is
+  begin
+      Print_Comment("Summary of " & Name);
+      Print_Param_Comment(To_String(Param.Name), "Summary of " & To_String(Param.Name));
+      Print_Return_Comment("Summary of return value");
+  end Print_Function_Comment;
+
+  procedure Print_Function_Comment(Name : String; Params : Parameter_Array) is
+  begin
+      Print_Comment("Summary of " & Name);
+      for Param of Params loop
+        Print_Param_Comment(To_String(Param.Name), "Summary of " & To_String(Param.Name));
+      end loop;
+      Print_Return_Comment("Summary of return value");
+  end Print_Function_Comment;
+
   procedure Print_Param_Comment(Name : String; Message : String) is
   begin
     Put_Line("--@param " & Name & " " & Message);
   end Print_Param_Comment;
+
+  procedure Print_Procedure_Comment(Name : String) is
+  begin
+    Print_Comment("Summary of " & Name);
+  end Print_Procedure_Comment;
+
+  procedure Print_Procedure_Comment(Name : String; Param : Parameter) is
+  begin
+     Print_Comment("Summary of " & Name);
+    Print_Param_Comment(To_String(Param.Name), "Summary of " & To_String(Param.Name));
+  end Print_Procedure_Comment;
+
+  procedure Print_Procedure_Comment(Name : String; Params : Parameter_Array) is
+  begin
+    Print_Comment("Summary of " & Name);
+    for Param of Params loop
+      Print_Param_Comment(To_String(Param.Name), "Summary of " & To_String(Param.Name));
+    end loop;
+  end Print_Procedure_Comment;
 
   procedure Print_Return_Comment(Message : String) is
   begin
@@ -197,7 +238,7 @@ package body Agen is
     Sanitized_Name : constant String := Sanitize_Name(Name);
   begin
     if Stub_Comments then
-      Print_Comment("Summary of " & Name);
+      Print_Procedure_Comment(Name);
     end if;
     Put_Line("procedure " & Sanitized_Name & " is");
     Put_Line("begin");
@@ -214,8 +255,7 @@ package body Agen is
     Sanitized_Name : constant String := Sanitize_Name(Name);
   begin
     if Stub_Comments then
-      Print_Comment("Summary of " & Name);
-      Print_Param_Comment(To_String(Param.Name), "Summary of " & To_String(Param.Name));
+      Print_Procedure_Comment(Name, Param);
     end if;
     Put_Line("procedure " & Sanitized_Name & "(" & To_String(Param.Name) & " : " & To_String(Param.Of_Type) & ") is");
     Put_Line("begin");
@@ -232,10 +272,7 @@ package body Agen is
     Sanitized_Name : constant String := Sanitize_Name(Name);
   begin
     if Stub_Comments then
-      Print_Comment("Summary of " & Name);
-      for Param of Params loop
-        Print_Param_Comment(To_String(Param.Name), "Summary of " & To_String(Param.Name));
-      end loop;
+      Print_Procedure_Comment(Name, Params);
     end if;
     Put("procedure " & Sanitized_Name & "(");
     for I in 1 .. Params'Length - 1 loop
@@ -266,8 +303,7 @@ package body Agen is
     Sanitized_Name : constant String := Sanitize_Name(Name);
   begin
     if Stub_Comments then
-      Print_Comment("Summary of " & Name);
-      Print_Return_Comment("Summary of return value");
+      Print_Function_Comment(Name);
     end if;
     Put_Line("function " & Sanitized_Name & " return " & Returns & " is");
     Put_Line("begin");
@@ -294,9 +330,7 @@ package body Agen is
     Sanitized_Name : constant String := Sanitize_Name(Name);
   begin
     if Stub_Comments then
-      Print_Comment("Summary of " & Name);
-      Print_Param_Comment(To_String(Param.Name), "Summary of " & To_String(Param.Name));
-      Print_Return_Comment("Summary of return value");
+      Print_Function_Comment(Name, Param);
     end if;
     Put_Line("function " & Sanitized_Name & "(" & To_String(Param.Name) & " : " & To_String(Param.Of_Type) & ") return " & Returns & " is");
     Put_Line("begin");
@@ -323,11 +357,7 @@ package body Agen is
     Sanitized_Name : constant String := Sanitize_Name(Name);
   begin
     if Stub_Comments then
-      Print_Comment("Summary of " & Name);
-      for Param of Params loop
-        Print_Param_Comment(To_String(Param.Name), "Summary of " & To_String(Param.Name));
-      end loop;
-      Print_Return_Comment("Summary of return value");
+      Print_Function_Comment(Name, Params);
     end if;
     Put("function " & Sanitized_Name & "(");
     -- Iterate through all but the last parameter, which is printed differently

--- a/src/agen.adb
+++ b/src/agen.adb
@@ -168,10 +168,20 @@ package body Agen is
     Put_Line("--@field " & Name & " " & Message);
   end Print_Field_Comment;
 
+  procedure Print_Function_Comment(Form : Parameter) is
+  begin
+    Print_Function_Comment(To_String(Form.Name));
+  end Print_Function_Comment;
+
   procedure Print_Function_Comment(Name : String) is
   begin
     Print_Comment("Summary of " & Name);
     Print_Return_Comment("Summary of return value");
+  end Print_Function_Comment;
+
+  procedure Print_Function_Comment(Form : Parameter; Param : Parameter) is
+  begin
+    Print_Function_Comment(To_String(Form.Name), Param);
   end Print_Function_Comment;
 
   procedure Print_Function_Comment(Name : String; Param : Parameter) is
@@ -179,6 +189,11 @@ package body Agen is
       Print_Comment("Summary of " & Name);
       Print_Param_Comment(To_String(Param.Name), "Summary of " & To_String(Param.Name));
       Print_Return_Comment("Summary of return value");
+  end Print_Function_Comment;
+
+  procedure Print_Function_Comment(Form : Parameter; Params : Parameter_Array) is
+  begin
+    Print_Function_Comment(To_String(Form.Name), Params);
   end Print_Function_Comment;
 
   procedure Print_Function_Comment(Name : String; Params : Parameter_Array) is

--- a/src/agen.ads
+++ b/src/agen.ads
@@ -45,9 +45,15 @@ package Agen is
 
   procedure Print_Field_Comment(Name : String; Message : String);
 
+  procedure Print_Function_Comment(Form : Parameter);
+
   procedure Print_Function_Comment(Name : String);
 
+  procedure Print_Function_Comment(Form : Parameter; Param : Parameter);
+
   procedure Print_Function_Comment(Name : String; Param : Parameter);
+
+  procedure Print_Function_Comment(Form : Parameter; Params : Parameter_Array);
 
   procedure Print_Function_Comment(Name : String; Params : Parameter_Array);
 

--- a/src/agen.ads
+++ b/src/agen.ads
@@ -45,7 +45,19 @@ package Agen is
 
   procedure Print_Field_Comment(Name : String; Message : String);
 
+  procedure Print_Function_Comment(Name : String);
+
+  procedure Print_Function_Comment(Name : String; Param : Parameter);
+
+  procedure Print_Function_Comment(Name : String; Params : Parameter_Array);
+
   procedure Print_Param_Comment(Name : String; Message : String);
+
+  procedure Print_Procedure_Comment(Name : String);
+
+  procedure Print_Procedure_Comment(Name : String; Param : Parameter);
+
+  procedure Print_Procedure_Comment(Name : String; Params : Parameter_Array);
 
   procedure Print_Return_Comment(Message : String);
 


### PR DESCRIPTION
I had the comment stub generators for function and procedures inside of the code generators. I factored them out so they're callable separately, and added the hooks for these to the command line parser.

I've updated the README.md to reflect the new syntax (print/p is no longer required, everything else is exactly the same)

Also, I added build instructions for `gprbuild` to the README.md. I left in the instructions for `gnatmake` although you may want to remove that one. So #12 should be closable now.